### PR TITLE
Add raw output files for active and aggregate domains

### DIFF
--- a/scripts/active-domains.ts
+++ b/scripts/active-domains.ts
@@ -7,6 +7,7 @@ const CURRENT_BLACKLIST = "https://raw.githubusercontent.com/doodad-labs/disposa
 
 const OUTPUT_DIR = path.join(__dirname, '..', 'out')
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'data', 'active.txt')
+const OUTPUT_RAW_FILE = path.join(OUTPUT_DIR, 'data', 'active.raw.txt')
 const STATS_FILE = path.join(OUTPUT_DIR, 'stats', 'badge-active.json')
 
 const blacklist = new Set()
@@ -36,7 +37,8 @@ async function main() {
     ].join('\n')
 
     await fs.mkdir(path.dirname(OUTPUT_FILE), { recursive: true })
-    await fs.writeFile(OUTPUT_FILE, [header, ...active_blacklist].join('\n'), 'utf-8')    
+    await fs.writeFile(OUTPUT_FILE, [header, ...active_blacklist].join('\n'), 'utf-8')
+    await fs.writeFile(OUTPUT_RAW_FILE, active_blacklist.join('\n'), 'utf-8')
 
     const stats = {
         "schemaVersion":1,

--- a/scripts/aggregate-domains.ts
+++ b/scripts/aggregate-domains.ts
@@ -9,7 +9,9 @@ const CURRENT_DOMAINS_BLACKLIST = "https://raw.githubusercontent.com/doodad-labs
 
 const OUTPUT_DIR = path.join(__dirname, '..', 'out')
 const OUTPUT_DOMAIN_FILE = path.join(OUTPUT_DIR, 'data', 'domains.txt')
+const OUTPUT_DOMAIN_RAW_FILE = path.join(OUTPUT_DIR, 'data', 'domains.raw.txt')
 const OUTPUT_ROOT_FILE = path.join(OUTPUT_DIR, 'data', 'root.txt')
+const OUTPUT_ROOT_RAW_FILE = path.join(OUTPUT_DIR, 'data', 'root.raw.txt')
 const STATS_FILE = path.join(OUTPUT_DIR, 'stats', 'badge.json')
 const STATS_ROOT_FILE = path.join(OUTPUT_DIR, 'stats', 'badge-root.json')
 
@@ -183,7 +185,8 @@ async function main() {
     const sorted_blacklist: string[] = blacklist_after_whitelist.sort()
 
     await fs.mkdir(path.dirname(OUTPUT_DOMAIN_FILE), { recursive: true })
-    await fs.writeFile(OUTPUT_DOMAIN_FILE, [header, ...sorted_blacklist].join('\n'), 'utf-8')    
+    await fs.writeFile(OUTPUT_DOMAIN_FILE, [header, ...sorted_blacklist].join('\n'), 'utf-8')
+    await fs.writeFile(OUTPUT_DOMAIN_RAW_FILE, sorted_blacklist.join('\n'), 'utf-8')
     
     for (const domain of sorted_blacklist) {
         const parsed = psl.get(domain);
@@ -196,6 +199,7 @@ async function main() {
 
     await fs.mkdir(path.dirname(OUTPUT_ROOT_FILE), { recursive: true })
     await fs.writeFile(OUTPUT_ROOT_FILE, [header, ...sorted_root_blacklist].join('\n'), 'utf-8')
+    await fs.writeFile(OUTPUT_ROOT_RAW_FILE, sorted_root_blacklist.join('\n'), 'utf-8')
     await fs.mkdir(path.dirname(STATS_FILE), { recursive: true })
 
     await fs.writeFile(STATS_FILE, JSON.stringify({


### PR DESCRIPTION
This pull request enhances the domain aggregation and active domain scripts by adding support for exporting raw, unformatted domain lists alongside the existing header-included files. The main goal is to generate both human-readable and machine-friendly outputs for downstream processing.

**Output file enhancements:**

* Added new output files `active.raw.txt`, `domains.raw.txt`, and `root.raw.txt` to the `out/data` directory, containing the raw lists of domains without headers for easier machine parsing. [[1]](diffhunk://#diff-eda4db9e16cb2de752fe8c9be0da51bcb3c4138ea1e5e6e8717d299968b1e83eR10) [[2]](diffhunk://#diff-fe68f7d065c077f808d47ab890cb44f64ac0c3d3de17bd82a75d59b87b1240dcR12-R14)
* Updated both `active-domains.ts` and `aggregate-domains.ts` scripts to write these raw files in addition to the existing header-included files. [[1]](diffhunk://#diff-eda4db9e16cb2de752fe8c9be0da51bcb3c4138ea1e5e6e8717d299968b1e83eR41) [[2]](diffhunk://#diff-fe68f7d065c077f808d47ab890cb44f64ac0c3d3de17bd82a75d59b87b1240dcR189) [[3]](diffhunk://#diff-fe68f7d065c077f808d47ab890cb44f64ac0c3d3de17bd82a75d59b87b1240dcR202)